### PR TITLE
Fix: 방 예약 조회시 Notfound 버그 수정

### DIFF
--- a/src/main/java/com/moyeorun/api/domain/room/dao/RoomRepository.java
+++ b/src/main/java/com/moyeorun/api/domain/room/dao/RoomRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
-  @Query("select rm  from Room rm join fetch rm.reservationList where rm.id = :id")
+  @Query("select rm  from Room rm left join fetch rm.reservationList where rm.id = :id")
   Optional<Room> findWithReservationById(Long id);
 
   @Query("select rm from Room  rm join fetch rm.runningList where rm.id = :id")


### PR DESCRIPTION
조회쿼리 innerJoin -> outerJoin

# 개발사항

(이슈 내용 긁어옴)
- 버그 설명
방 예약하기 요청에서 JPQL "`@Query("select rm from Room rm join fetch rm.reservationList where rm.id = :id")`"
RoomRepository의 findWithReservationById JPQL 메소드 문 문제.
fetchJoin 은 기본적으로 inner Join을 처리하는데. inner join은 room의 예약정보가 없으면 null로 처리가 됨.
방 생성시 방의 정보는 table에 존재하나 예약자 정보는 없기 때문에, 방 생성후 예약하기를 보낼 시에 해당 메소드는 무조건 Optional.Empty로 리턴이 된다.
- 맞는 동작
예악 정보가 없으면 room의 정보만을 가져올 수 있어야 함.
outer join으로 처리를 하면 해결 가능

AS-IS
<img width="250" alt="image" src="https://user-images.githubusercontent.com/28949213/187866328-088b6aed-52c6-4af9-aea3-938e20416096.png">


TO-BE
<img width="250" alt="image" src="https://user-images.githubusercontent.com/28949213/187866174-f8673e69-5339-4261-8946-1af841921c97.png">


## 추가사항

Closes #14 